### PR TITLE
Allow hiding the card until x days before event

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Configuration parameters:<br />
 **icon_size** (optional): size of the icon. Defaults to 25px.<br />
 **hide_date** (optional): hide date. Defaults to false.<br />
 **hide_days** (optional): hide number of days. Defaults to false.<br />
+**hide_before** (optional): hide entire card until x days before event.  Defaults to not hiding card.<br />
 <p>
 Please find below an example of ui-lovelace.yaml (entity should be the sensor of garbage_collection platform you defined):
 
@@ -39,6 +40,7 @@ resources:
         hide_date: true
       - type: custom:garbage-collection-card
         entity: sensor.waste
+        hide_before: 4
         icon_color: '#0561ba'
 ```
 

--- a/garbage-collection-card.js
+++ b/garbage-collection-card.js
@@ -160,7 +160,7 @@ class GarbageCollectionCard extends HTMLElement {
     this._config = cardConfig;
   }
 
-  _updateContent(element, attributes, hdate, hdays) {
+  _updateContent(element, attributes, hdate, hdays, hcard) {
     element.innerHTML = `
       ${attributes.map((attribute) => `
         <tr>
@@ -176,6 +176,8 @@ class GarbageCollectionCard extends HTMLElement {
         </tr>
       `).join('')}
     `;
+
+    this.style.display = hcard?"none":"block";
   }
 
   set hass(hass) {
@@ -187,10 +189,19 @@ class GarbageCollectionCard extends HTMLElement {
     if (typeof config.hide_date != "undefined") hide_date=config.hide_date
     let hide_days = false;
     if (typeof config.hide_days != "undefined") hide_days=config.hide_days
+    let hide_card = false;
+    let hide_before = -1;
+    if (typeof config.hide_before != "undefined") hide_before=config.hide_before
 
     let attributes = this._getAttributes(hass, config.entity.split(".")[1]);
+    if (hide_before>-1) {
+      let iDays = parseInt(attributes[0].days,10);
+      if (iDays > hide_before) {
+        hide_card = true;
+      }
+    }
 
-    this._updateContent(root.getElementById('attributes'), attributes, hide_date, hide_days );
+    this._updateContent(root.getElementById('attributes'), attributes, hide_date, hide_days, hide_card );
   }
 
   getCardSize() {


### PR DESCRIPTION
Love the card! 

This is just a quick PR to add a 'hide_before' option (specified in days) to hide the card entirely until x days before the event.  I know I could use a conditional card, but this seems much cleaner.

