### PR TITLE
Update Swedish translation for 'due'

### DIFF
--- a/dist/sv.json
+++ b/dist/sv.json
@@ -6,8 +6,8 @@
         "Tomorrow": "Imorgon"
     },
     "other": {
-      "due": "förfaller",
-      "Due": "Förfaller",
+      "due": "genomförs",
+      "Due": "Genomförs",
       "due_today_order": "true",
       "in_days": "om DAYS dagar"
     }


### PR DESCRIPTION
This is a more relevant Swedish translation of the English word 'due' in this use case.