### PR TITLE
Icon cell customisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Configuration parameters:<br />
 | due_txt | **Y** | `false` | For today/tomorrow pick-ups use 'Due today' or 'Due tomorrow'.|
 | icon_color | **Y** | theme's icon color | icon color. Accepts both color names and RGB values.|
 | icon_size | **Y** | `25px` | size of the icon.|
+| icon_cell_padding | **Y** | `35px` | padding applied to icon cell.|
+| icon_cell_width | **Y** | `60px` | icon cell width.|
 | hass_lang_priority | **Y** | `false` | whether HASS language has priority over browser language.|
 | hide_date | **Y** | `false` | hide date.|
 | hide_days | **Y** | `false`| hide number of days. Automatically set to true when collection is due today or tomorrow.|

--- a/dist/garbage-collection-card.js
+++ b/dist/garbage-collection-card.js
@@ -57,6 +57,8 @@ class GarbageCollectionCard extends HTMLElement {
       due_txt: false,
       icon_color: 'var(--paper-item-icon-color)',
       icon_size: '25px',
+      icon_cell_padding: '35px',
+      icon_cell_width: '60px',
       hass_lang_priority: false,
       hide_date: false,
       hide_days: false,
@@ -84,8 +86,8 @@ class GarbageCollectionCard extends HTMLElement {
         font-size: 120%;
       }
       .tdicon {
-        padding-left: 35px;
-        width: 60px;
+        padding-left: ${cardConfig.icon_cell_padding};
+        width: ${cardConfig.icon_cell_width};
       }
       ha-icon-button {
         color: ${cardConfig.icon_color};


### PR DESCRIPTION
Added the options to change the icon cell padding and width to enable UI customisation.
This is needed when using grid cards and viewing on a small screen.