### PR TITLE
Fix for slow or no loading at start

### DIFF
--- a/dist/garbage-collection-card.js
+++ b/dist/garbage-collection-card.js
@@ -246,6 +246,8 @@ class GarbageCollectionCard extends HTMLElement {
     if (!this._firstLoad) {
       this._firstLoad = true;
 
+      this.source = source;
+      
       this.llocale = window.navigator.userLanguage || window.navigator.language;
       if (config.hass_lang_priority) {
         this.llocale = this.myhass.language;
@@ -334,7 +336,7 @@ class GarbageCollectionCard extends HTMLElement {
         }
       }
     }
-    this.source = source;
+    
     this._updateContent(attributes, hide_date, hide_days, hide_card, due_txt, hide_on_click, hide_title, hide_icon, hide_dow, dow_format, source);
   }
 


### PR DESCRIPTION
I always noticed that most of the time the card was initially empty and only after some time it was properly rendered. Sometimes the card wasn't rendering at all.

I spent some minutes on the code and found the issue:

https://github.com/amaximus/garbage-collection-card/blob/68971f98d6269d65b210d6171a288534f685a215/dist/garbage-collection-card.js#L273

was fired before

https://github.com/amaximus/garbage-collection-card/blob/68971f98d6269d65b210d6171a288534f685a215/dist/garbage-collection-card.js#L337

and thus the _updateContent method was not able to read this.source.

This PR fixes the issue by setting this.source on first load at soon as possible.

No more issues!